### PR TITLE
WIP Scene Feature Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,32 @@
 
 
 ## Overview
-LabelMate Scene provides a small integration that creates a logical groups of switchs or lights driven by Home Assistant "labels" or can be tied more specifically to a scene. It dynamically watches entities that have a given label and/or scene.
+LabelMate Scene provides a small integration that creates logical groups of switches or lights driven by Home Assistant "labels" or can be tied more specifically to scenes. It dynamically watches entities that have a given label and/or scene.
 
 - A Switch or Light entity (depending on the selected group type) that controls all matched entities.
 - Two sensors: active count (number of matched entities that are "on") and total count (number of matched entities).
 
 This integration prefers scenes when turning the group on/off: if you add scenes that have the same label, the integration will attempt to activate a matching scene instead of directly toggling members ON or OFF. If there is no scene, it directly toggles the tagged members on or off. See Notes on Behavior below.
 
+In **Scene Mode**, the integration creates one switch per label that aggregates all entities from multiple scenes sharing that label. Turning the switch ON activates the first scene alphabetically; turning it OFF deactivates all aggregated entities across all matching scenes.
+
 ## Group Types
 
-Switch/Light:
+**Switch/Light:**
 - Scans for entities which are using the configured label
 - Creates a switch or light which appears as a group in the UI
 - In its default (no labeled scene found) state will turn on as soon as any labeled light or switch is ON and OFF when all are off
 - Will search for a scene with the SAME label and if "off" is not found in the name, activate the scene, even if that means not all devices are in that scene or label.
 - When turning it OFF, it will search for a scene with the configured label and if "off" is found in the name, use it will activate the scene, even if that means not all devices are in that scene or label and will continue to represent the state of the labeled devices.
 
-In Scene Mode:
-- Scans for scenes that have the configured label
-- Creates switches for all labeled scenes with the configured label
-- Turning ON the switch will activate the switch
-- Turning OFF the switch will scan for all entities and devices in the applicable scene and turn them OFF
+**Scene Mode:**
+- Scans for **all scenes** that have the configured label
+- Creates **one switch per label** (not per scene) that aggregates entities from all matching scenes
+- The group includes all unique entities and devices from every scene with that label
+- **Turning ON**: Activates the **first scene alphabetically** from all scenes with that label
+- **Turning OFF**: Turns off **ALL entities** aggregated from all scenes with that label (can span multiple scenes)
+- Properly handles both individual entities and devices added to scenes
+- Dynamically updates when scenes are added, removed, or modified
 
 ## Status & Notes
 This integration is actively evolving. Scene-only groups may report zero-valued sensors; behavior and corner cases continue to be refined. Use at your own risk; your mileage may vary.
@@ -80,16 +85,23 @@ If/when this project is published to HACS, install it from HACS and restart Home
 ## Notes on behavior
 - Membership is dynamic and event-driven: the integration watches the entity/device/label registries and state changes to recompute which entities match the label. It filters to allowed domains (lights, switches, fans, input_booleans by default).
 - The "Light" variant reports a computed `brightness` and supports RGB color in the UI (color is configurable as options on the config entry).
-- When turning the group ON or OFF, the integration first attempts to find a Scene that matches the same label. Matching rules:
+- When turning the group ON or OFF (for Switch/Light types), the integration first attempts to find a Scene that matches the same label. Matching rules:
   - Scene entity must have the same label attached.
   - For ON actions: the scene name must NOT contain the word "off" (case-insensitive).
   - For OFF actions: the scene name MUST contain the word "off".
   - If multiple matches exist, the integration picks the first alphabetical scene entity id.
+- **Scene Mode behavior:**
+  - Creates one switch per label that aggregates entities from all scenes with that label
+  - Supports both entities and devices added to scenes (devices are expanded to their constituent entities)
+  - Turn ON: Activates the first alphabetically-sorted scene
+  - Turn OFF: Deactivates all entities from all scenes with that label
+  - The switch state reflects whether any aggregated entities are currently on
 
 ## Troubleshooting
 - The integration matches labels using Home Assistant's label system. If you do not see expected entities, verify the label is attached to the entity (check Settings → Devices & Services → Entities and confirm the "Labels" field).
 - If the group's entity shows zero total members, verify that matched entities are in allowed domains: the integration filters to a small set (light, switch, fan, input_boolean) by default. You can change `ALLOWED_DOMAINS` in `const.py` to include other domains if needed.
 - Scene activation rules: Scene matching is based on labels attached to the scene entity. If scenes are not being activated, ensure the scene entity has the label set in the entity registry.
+- **Scene Mode**: If entities aren't being detected from scenes, ensure the scene includes actual entities or devices. The integration extracts both direct entity references and expands device references to their constituent entities.
 
 Improvement Ideas
 -----------------
@@ -102,5 +114,6 @@ Todos
 -----
 Current tasks and status for this integration repository:
 - [ ] Evaluate adding area support — Assess how to add area-based groups (design, API usage, config flow, migration, tests). (in progress)
-- [ ] Fix zero sensor values for the Scene option
+- [x] ~~Fix zero sensor values for the Scene option~~ — Scene mode now aggregates entities properly
+- [x] ~~Move to one switch per label instead of per scene~~ — Implemented with entity aggregation across scenes
 - [ ] Move Sensor values tied to switch and light options to an attribute on the Light or Switch. Will improve support for the Scene option where we might have multiple switches on a single device.

--- a/custom_components/labelmate_scene/switch.py
+++ b/custom_components/labelmate_scene/switch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -15,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up LabelGroupSwitch or scene-backed switches depending on type."""
+    """Set up LabelGroupSwitch for both standard and scene-based label groups."""
     # Prefer explicit options, fall back to stored data, then default to switch
     gtype = entry.options.get(CONF_GROUP_TYPE) or entry.data.get(CONF_GROUP_TYPE) or GROUP_TYPE_SWITCH
     _LOGGER.debug(
@@ -27,22 +28,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
 
-    if gtype == GROUP_TYPE_SWITCH:
-        async_add_entities([LabelGroupSwitch(hass, coordinator, entry)])
-        return
-
-    # If this entry is configured as scene type, create one switch per matching scene
-    if gtype == GROUP_TYPE_SCENE:
-        scenes = coordinator.data.get("scenes", [])
-        scene_names = coordinator.data.get("scene_names", {})
-        entities: list[LabelGroupSwitch] = []
-        for scene_eid in scenes:
-            name = scene_names.get(scene_eid) or scene_eid
-            entities.append(LabelSceneSwitch(hass, coordinator, entry, scene_eid, name))
-
-        if entities:
-            async_add_entities(entities)
-        return
+    # Create a single switch for all group types (switch, light, scene)
+    # Scene groups now aggregate all entities from all scenes with the label
+    async_add_entities([LabelGroupSwitch(hass, coordinator, entry)])
+    return
 
 
 class LabelGroupSwitch(LabelGroupBase, SwitchEntity):
@@ -55,140 +44,98 @@ class LabelGroupSwitch(LabelGroupBase, SwitchEntity):
         self._attr_name = f"Label {entry.data.get('label_name')} Group"
         # Keep a slugified label for consistent internal usage
         self._label_slug = slugify_label(entry.data.get("label_name"))
-
-
-class LabelSceneSwitch(LabelGroupBase, SwitchEntity):
-    """Switch representing a scene that matched the configured label."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        coordinator,
-        entry,
-        scene_entity_id: str,
-        scene_name: str,
-    ):
-        super().__init__(hass, coordinator, entry.entry_id, entry.data)
-
-        self._scene_entity_id = scene_entity_id
-        self._scene_name = scene_name
-        # stable unique id derived from entry and scene id
-        self._attr_unique_id = f"{entry.entry_id}:scene:{scene_entity_id}"
-        label = entry.data.get("label_name")
-        self._attr_name = f"{label} — {scene_name}"
-        self._label_slug = slugify_label(label)
-
-    async def async_added_to_hass(self) -> None:
-        """When added, attach coordinator listener and schedule name-sync."""
-        await super().async_added_to_hass()
-        # Sync entity registry name to the auto-generated name if the user hasn't customized it.
-        self.hass.async_create_task(self._sync_registry_name())
-
-    async def _sync_registry_name(self) -> None:
-        """Update the entity registry name to the auto-name unless user renamed it.
-
-        Rule: if the registry name is empty/None or it follows the previous auto-name
-        pattern ("{label} — ..."), update it to the current auto-name. If the user
-        has already renamed the entity to something else, preserve their name.
-        """
-        try:
-            reg = async_get_entity_registry(self.hass)
-            entry = reg.entities.get(self.entity_id)
-            if not entry:
-                return
-
-            current_name = entry.name
-            desired = self._attr_name
-
-            # If registry has no custom name or it looks like a prior auto-name, update it
-            if current_name is None or (
-                isinstance(current_name, str) and current_name.startswith(f"{self._label} ")
-            ):
-                # async_update_entity may be an awaitable
-                try:
-                    await reg.async_update_entity(self.entity_id, name=desired)
-                    _LOGGER.debug(
-                        "Synced entity registry name for %s -> %s",
-                        self.entity_id,
-                        desired,
-                    )
-                except Exception:
-                    # Best-effort: don't fail setup if update isn't available
-                    _LOGGER.debug("Entity registry update not supported for %s", self.entity_id)
-        except Exception:
-            _LOGGER.exception("Failed to sync registry name for %s", self.entity_id)
-
-    @property
-    def is_on(self):
-        """LED: consider the scene ON if any of its referenced entities are ON."""
-        scene_entities = self.coordinator.data.get("scene_entities", {}).get(self._scene_entity_id, [])
-        for e in scene_entities:
-            s = self.hass.states.get(e)
-            if s is not None and s.state == "on":
-                return True
-        return False
+        # Store group type for scene-specific logic
+        self._group_type = entry.options.get(CONF_GROUP_TYPE) or entry.data.get(CONF_GROUP_TYPE) or GROUP_TYPE_SWITCH
 
     async def async_turn_on(self, **kwargs):
-        """Activate the scene."""
-        await self.hass.services.async_call(
-            "scene",
-            "turn_on",
-            {"entity_id": self._scene_entity_id},
-            blocking=True,
-        )
-
-        # Schedule a short delayed refresh of the coordinator to pick up
-        # immediate state changes caused by the scene activation. This reduces
-        # race windows where async_turn_off might run against stale data.
-        async def _delayed_refresh():
-            try:
-                await asyncio.sleep(0.5)
-                await self.coordinator.async_request_refresh()
+        """Turn on logic: activate first scene alphabetically for scene groups."""
+        # For scene groups, activate the first alphabetically sorted scene
+        if self._group_type == GROUP_TYPE_SCENE:
+            scenes = self.coordinator.data.get("scenes", [])
+            if scenes:
+                # Sort scenes alphabetically
+                sorted_scenes = sorted(scenes)
+                first_scene = sorted_scenes[0]
+                
                 _LOGGER.debug(
-                    "Requested delayed coordinator refresh after activating scene %s",
-                    self._scene_entity_id,
+                    "[%s] Scene group activating first scene (alphabetically): %s",
+                    self._entry_id,
+                    first_scene,
                 )
-            except Exception:
-                _LOGGER.exception("Failed delayed coordinator refresh for %s", self._scene_entity_id)
-
-        # Fire-and-forget: we don't need to await this during the service call.
-        self.hass.async_create_task(_delayed_refresh())
+                
+                # Begin suppression window
+                self._forced_state = True
+                self._suppress_updates_until = time.time() + 1.0
+                
+                # Optimistic UI
+                self._attr_is_on = True
+                self.async_write_ha_state()
+                
+                # Activate the scene
+                await self.hass.services.async_call(
+                    "scene",
+                    "turn_on",
+                    {"entity_id": first_scene},
+                    blocking=True,
+                )
+                
+                # Schedule a delayed refresh
+                async def _delayed_refresh():
+                    try:
+                        await asyncio.sleep(0.5)
+                        await self.coordinator.async_request_refresh()
+                    except Exception:
+                        pass
+                
+                self.hass.async_create_task(_delayed_refresh())
+                return
+        
+        # For non-scene groups, use base class logic
+        await super().async_turn_on(**kwargs)
 
     async def async_turn_off(self, **kwargs):
-        """Turn off entities referenced by the scene (best-effort)."""
-        scene_entities = self.coordinator.data.get("scene_entities", {}).get(self._scene_entity_id, [])
-        if not scene_entities:
-            _LOGGER.warning(
-                "%s: scene %s has no discovered entities to turn off",
-                self.entity_id,
-                self._scene_entity_id,
-            )
-            return
-
-        _LOGGER.debug(
-            "%s: turning off scene %s -> entities=%s",
-            self.entity_id,
-            self._scene_entity_id,
-            scene_entities,
-        )
-
-        # Use the homeassistant.turn_off service to turn off all referenced entities
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_off",
-            {"entity_id": list(scene_entities)},
-            blocking=True,
-        )
-
-        # Immediately refresh coordinator to pick up the new states
-        try:
-            await self.coordinator.async_request_refresh()
+        """Turn off logic: turn off all entities from all scenes for scene groups."""
+        # For scene groups, turn off all aggregated entities
+        if self._group_type == GROUP_TYPE_SCENE:
+            data = self.coordinator.data or {}
+            targets = data.get("targets") or []
+            
+            if not targets:
+                _LOGGER.debug(
+                    "[%s] Scene group turn off: no aggregated entities found",
+                    self._entry_id,
+                )
+                return
+            
             _LOGGER.debug(
-                "Requested immediate coordinator refresh after turning off scene %s",
-                self._scene_entity_id,
+                "[%s] Scene group turning off %d aggregated entities",
+                self._entry_id,
+                len(targets),
             )
-        except Exception:
-            _LOGGER.exception(
-                "Failed to request coordinator refresh after turning off %s",
-                self._scene_entity_id,
+            
+            # Begin suppression window
+            self._forced_state = False
+            self._suppress_updates_until = time.time() + 1.0
+            
+            # Optimistic UI
+            self._attr_is_on = False
+            self.async_write_ha_state()
+            
+            # Turn off all aggregated entities
+            await self.hass.services.async_call(
+                "homeassistant",
+                "turn_off",
+                {"entity_id": list(targets)},
+                blocking=True,
             )
+            
+            # Immediately refresh coordinator
+            try:
+                await self.coordinator.async_request_refresh()
+            except Exception:
+                pass
+            
+            return
+        
+        # For non-scene groups, use base class logic
+        await super().async_turn_off(**kwargs)

--- a/custom_components/labelmate_scene/switch.py
+++ b/custom_components/labelmate_scene/switch.py
@@ -25,10 +25,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
         gtype,
         entry.options,
     )
+    
+    # Only create switch entity for switch and scene group types, not for light
+    from .const import GROUP_TYPE_LIGHT
+    if gtype == GROUP_TYPE_LIGHT:
+        return  # do not load switch entity
+    
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
 
-    # Create a single switch for all group types (switch, light, scene)
+    # Create a single switch for switch and scene group types
     # Scene groups now aggregate all entities from all scenes with the label
     async_add_entities([LabelGroupSwitch(hass, coordinator, entry)])
     return


### PR DESCRIPTION
Evaluating how to handle multiple scenes tagged. 

- Will aggregate devices/entities across all scenes with the same label
- Turning off will turn off all devices/entities that are found in the shared label scenes.
- Turning the switch ON will activate the first scene by alphabetic sorting.